### PR TITLE
Support configurable docker daemon host (-H cmd line arg)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
                                 <pomInclude>up-skip/pom.xml</pomInclude>
                                 <pomInclude>up-verbose/pom.xml</pomInclude>
                                 <pomInclude>up-api-version/pom.xml</pomInclude>
+                                <pomInclude>up-down-host/pom.xml</pomInclude>
                             </pomIncludes>
                             <postBuildHookScript>verify</postBuildHookScript>
                             <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>

--- a/src/it/up-down-host/docker-compose.yml
+++ b/src/it/up-down-host/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.2'
+services:
+  test:
+    image: busybox
+    container_name: mpdc-it-down
+    command: sleep 600

--- a/src/it/up-down-host/pom.xml
+++ b/src/it/up-down-host/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.dkanejs.maven.plugins.it</groupId>
+    <artifactId>down</artifactId>
+    <version>1.0</version>
+
+    <description>Verify "docker-compose down" runs.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>up</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>up</goal>
+                        </goals>
+                        <configuration>
+                            <detachedMode>true</detachedMode>
+                            <host>unix:///var/run/docker.sock</host>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>down</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>down</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/up-down-host/verify.groovy
+++ b/src/it/up-down-host/verify.groovy
@@ -1,0 +1,14 @@
+import java.nio.file.Paths
+
+String buildLog = new File("${basedir}/build.log").getText("UTF-8")
+
+String composeFile = Paths.get("${basedir}/docker-compose.yml").toString()
+
+assert buildLog.contains("Running: docker-compose -f $composeFile -H unix:///var/run/docker.sock up -d --no-color" as CharSequence)
+assert buildLog.contains("Running: docker-compose -f $composeFile down" as CharSequence)
+
+def cleanUpProcess = new ProcessBuilder("docker", "system", "prune", "-a", "-f").start().waitFor()
+
+assert cleanUpProcess == 0
+
+

--- a/src/main/java/com/dkanejs/maven/plugins/docker/compose/AbstractDockerComposeMojo.java
+++ b/src/main/java/com/dkanejs/maven/plugins/docker/compose/AbstractDockerComposeMojo.java
@@ -18,6 +18,12 @@ import java.util.Map;
 abstract class AbstractDockerComposeMojo extends AbstractMojo {
 
 	/**
+	 * Docker host to interact with
+	 */
+	@Parameter(property = "dockerCompose.host")
+	String host;
+
+	/**
 	 * Remove volumes on down
 	 */
 	@Parameter(defaultValue = "false", property = "dockerCompose.removeVolumes")
@@ -102,6 +108,11 @@ abstract class AbstractDockerComposeMojo extends AbstractMojo {
 
 		if (verbose) {
 			cmd.add("--verbose");
+		}
+
+		if (host != null) {
+			cmd.add("-H");
+			cmd.add(host);
 		}
 
 		cmd.addAll(args);


### PR DESCRIPTION
This commit provides a way to pass -H argument to docker-compose by specifying `<host>…</host>` plugin configuration option.