### PR TITLE
Multiple Docker compose files support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ This can be changed in the configuration section of the plugin:
 </configuration>
 ```
 
+If the property `composeFiles` which allows multiple compose files is present then the value of this `composeFile` property is ignored.
+
+#### composeFiles
+`composeFiles` - Location of multiple compose files. If this property is present then the value of the `composeFile` is ignored.
+
+This can be configured in the configuration section of the plugin:
+```
+<configuration>
+    <composeFiles>
+        <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+        <composeFile>${project.basedir}/docker-compose.override.yml</composeFile>
+    </composeFiles>
+</configuration>
+```
+
 #### detachedMode
 `detachedMode` - Run in detached mode
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.dkanejs.maven.plugins</groupId>
     <artifactId>docker-compose-maven-plugin</artifactId>
-    <version>2.0.1</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <packaging>maven-plugin</packaging>
 
@@ -125,6 +125,8 @@
                                 <pomInclude>up-verbose/pom.xml</pomInclude>
                                 <pomInclude>up-api-version/pom.xml</pomInclude>
                                 <pomInclude>up-down-host/pom.xml</pomInclude>
+                                <pomInclude>up-down-multiple-compose-files/pom.xml</pomInclude>
+                                <pomInclude>up-down-multiple-compose-files-ignoring-single/pom.xml</pomInclude>
                             </pomIncludes>
                             <postBuildHookScript>verify</postBuildHookScript>
                             <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>

--- a/src/it/up-down-host/pom.xml
+++ b/src/it/up-down-host/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.dkanejs.maven.plugins.it</groupId>
-    <artifactId>down</artifactId>
+    <artifactId>up-down-host</artifactId>
     <version>1.0</version>
 
     <description>Verify "docker-compose down" runs.</description>

--- a/src/it/up-down-multiple-compose-files-ignoring-single/docker-compose.ignored.yml
+++ b/src/it/up-down-multiple-compose-files-ignoring-single/docker-compose.ignored.yml
@@ -1,0 +1,6 @@
+version: '3.2'
+services:
+  test:
+    image: busybox
+    container_name: mpdc-it-down
+    command: sleep 600

--- a/src/it/up-down-multiple-compose-files-ignoring-single/docker-compose.override.yml
+++ b/src/it/up-down-multiple-compose-files-ignoring-single/docker-compose.override.yml
@@ -1,0 +1,6 @@
+version: '3.2'
+services:
+  test:
+    image: busybox
+    container_name: mpdc-it-down
+    command: sleep 600

--- a/src/it/up-down-multiple-compose-files-ignoring-single/docker-compose.yml
+++ b/src/it/up-down-multiple-compose-files-ignoring-single/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.2'
+services:
+  test:
+    image: busybox
+    container_name: mpdc-it-down
+    command: sleep 600

--- a/src/it/up-down-multiple-compose-files-ignoring-single/pom.xml
+++ b/src/it/up-down-multiple-compose-files-ignoring-single/pom.xml
@@ -4,10 +4,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.dkanejs.maven.plugins.it</groupId>
-    <artifactId>down-remove-volumes</artifactId>
+    <artifactId>up-down-multiple-compose-files-ignoring-single</artifactId>
     <version>1.0</version>
 
-    <description>Verify "docker-compose down --rmi local" runs.</description>
+    <description>Verify "docker-compose up" and "docker-compose down" runs with multiple docker compose files and ignoring single compose file definition.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -26,10 +26,6 @@
                         <goals>
                             <goal>up</goal>
                         </goals>
-                        <configuration>
-                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
-                            <detachedMode>true</detachedMode>
-                        </configuration>
                     </execution>
                     <execution>
                         <id>down</id>
@@ -37,13 +33,16 @@
                         <goals>
                             <goal>down</goal>
                         </goals>
-                        <configuration>
-                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
-                            <removeImages>true</removeImages>
-                            <removeImagesType>local</removeImagesType>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <composeFile>${project.basedir}/docker-compose.ignored.yml</composeFile>
+                    <composeFiles>
+                        <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                        <composeFile>${project.basedir}/docker-compose.override.yml</composeFile>
+                    </composeFiles>
+                    <detachedMode>true</detachedMode>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/it/up-down-multiple-compose-files-ignoring-single/verify.groovy
+++ b/src/it/up-down-multiple-compose-files-ignoring-single/verify.groovy
@@ -1,0 +1,15 @@
+import java.nio.file.Paths
+
+String buildLog = new File("${basedir}/build.log").getText("UTF-8")
+
+String composeFile = Paths.get("${basedir}/docker-compose.yml").toString()
+String composeFileOverride = Paths.get("${basedir}/docker-compose.override.yml").toString()
+
+assert buildLog.contains("Running: docker-compose -f $composeFile -f $composeFileOverride up -d --no-color" as CharSequence)
+assert buildLog.contains("Running: docker-compose -f $composeFile -f $composeFileOverride down" as CharSequence)
+
+def cleanUpProcess = new ProcessBuilder("docker", "system", "prune", "-a", "-f").start().waitFor()
+
+assert cleanUpProcess == 0
+
+

--- a/src/it/up-down-multiple-compose-files/docker-compose.override.yml
+++ b/src/it/up-down-multiple-compose-files/docker-compose.override.yml
@@ -1,0 +1,6 @@
+version: '3.2'
+services:
+  test:
+    image: busybox
+    container_name: mpdc-it-down
+    command: sleep 600

--- a/src/it/up-down-multiple-compose-files/docker-compose.yml
+++ b/src/it/up-down-multiple-compose-files/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.2'
+services:
+  test:
+    image: busybox
+    container_name: mpdc-it-down
+    command: sleep 600

--- a/src/it/up-down-multiple-compose-files/pom.xml
+++ b/src/it/up-down-multiple-compose-files/pom.xml
@@ -4,10 +4,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.dkanejs.maven.plugins.it</groupId>
-    <artifactId>down-remove-volumes</artifactId>
+    <artifactId>up-down-multiple-compose-files</artifactId>
     <version>1.0</version>
 
-    <description>Verify "docker-compose down --rmi local" runs.</description>
+    <description>Verify "docker-compose up" and "docker-compose down" runs with multiple docker compose files.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -26,10 +26,6 @@
                         <goals>
                             <goal>up</goal>
                         </goals>
-                        <configuration>
-                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
-                            <detachedMode>true</detachedMode>
-                        </configuration>
                     </execution>
                     <execution>
                         <id>down</id>
@@ -37,13 +33,15 @@
                         <goals>
                             <goal>down</goal>
                         </goals>
-                        <configuration>
-                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
-                            <removeImages>true</removeImages>
-                            <removeImagesType>local</removeImagesType>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <composeFiles>
+                        <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                        <composeFile>${project.basedir}/docker-compose.override.yml</composeFile>
+                    </composeFiles>
+                    <detachedMode>true</detachedMode>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/it/up-down-multiple-compose-files/verify.groovy
+++ b/src/it/up-down-multiple-compose-files/verify.groovy
@@ -1,0 +1,15 @@
+import java.nio.file.Paths
+
+String buildLog = new File("${basedir}/build.log").getText("UTF-8")
+
+String composeFile = Paths.get("${basedir}/docker-compose.yml").toString()
+String composeFileOverride = Paths.get("${basedir}/docker-compose.override.yml").toString()
+
+assert buildLog.contains("Running: docker-compose -f $composeFile -f $composeFileOverride up -d --no-color" as CharSequence)
+assert buildLog.contains("Running: docker-compose -f $composeFile -f $composeFileOverride down" as CharSequence)
+
+def cleanUpProcess = new ProcessBuilder("docker", "system", "prune", "-a", "-f").start().waitFor()
+
+assert cleanUpProcess == 0
+
+


### PR DESCRIPTION
The support for multiple docker compose files has been added in a
backward compatible manner by introducing a new configuration property:

 composeFiles

As name indicates it is a plural form of the original `composeFile`
property which is still present and valid to use.

If the new property `composeFiles` is defined the value of the original
`composeFile` is ignored. A better approach would be to log warning if
user set both the `composeFile` and `composeFiles`. However this is not
possible as the `composeFile` has always a default value, hence is
always defined.