### PR TITLE
Allow setting of environment variables from plugin configuration (closes #54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,38 @@ This can be configured in the configuration section of the plugin:
 </configuration>
 ```
 
+#### envFile
+`envFile` - Location of a file containing environment variables for docker-compose in key=value format, one pair per line. 
+
+This can be configured in the configuration section of the plugin:
+```xml
+<configuration>
+    <envFile>${project.basedir}/.env</envFile>
+</configuration>
+```
+
+#### envVars
+`envVars` - Environment variables to be set when running docker-compose. Values set here override those set in a configured `envFile`.
+
+This can be configured in the configuration section of the plugin:
+```xml
+<configuration>
+    <envVars>
+        <serviceName>${project.groupId}.${project.artifactId}</serviceName>
+    </envVars>
+</configuration>
+```
+
+This allows you to parameterize your `docker-compose.yml`:
+
+```yaml
+version: '3.2'
+services:
+  service:
+    image: busybox
+    container_name: ${serviceName}-1
+```
+
 #### services
 `services` - Names of services.
 

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
                                 <pomInclude>up-down-multiple-compose-files-ignoring-single/pom.xml</pomInclude>
                                 <pomInclude>up-down-services/pom.xml</pomInclude>
                                 <pomInclude>up-env/pom.xml</pomInclude>
+                                <pomInclude>up-env-vars/pom.xml</pomInclude>
                                 <pomInclude>up-skip/pom.xml</pomInclude>
                                 <pomInclude>up-verbose/pom.xml</pomInclude>
                             </pomIncludes>

--- a/src/it/up-env-vars/docker-compose.yml
+++ b/src/it/up-env-vars/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.2'
+services:
+  test:
+    image: busybox
+    container_name: mpdc-it-up-env
+    command: echo -e Docker Compose has run successfully with message ${prefix}${suffix}

--- a/src/it/up-env-vars/docker-compose.yml
+++ b/src/it/up-env-vars/docker-compose.yml
@@ -2,5 +2,5 @@ version: '3.2'
 services:
   test:
     image: busybox
-    container_name: mpdc-it-up-env
+    container_name: mpdc-it-up-env-vars
     command: echo -e Docker Compose has run successfully with message ${prefix}${suffix}

--- a/src/it/up-env-vars/pom.xml
+++ b/src/it/up-env-vars/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.dkanejs.maven.plugins.it</groupId>
-    <artifactId>up</artifactId>
+    <artifactId>up-env-vars</artifactId>
     <version>1.0</version>
 
     <description>Verify "docker-compose up" runs.</description>

--- a/src/it/up-env-vars/pom.xml
+++ b/src/it/up-env-vars/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.dkanejs.maven.plugins.it</groupId>
+    <artifactId>up</artifactId>
+    <version>1.0</version>
+
+    <description>Verify "docker-compose up" runs.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>up</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>up</goal>
+                        </goals>
+                        <configuration>
+                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                            <envVars>
+                                <prefix>boom</prefix>
+                                <suffix>shakalaka</suffix>
+                            </envVars>
+                            <detachedMode>false</detachedMode>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/up-env-vars/verify.groovy
+++ b/src/it/up-env-vars/verify.groovy
@@ -1,0 +1,12 @@
+import java.nio.file.Paths
+
+String buildLog = new File("${basedir}/build.log").getText("UTF-8")
+
+String composeFile = Paths.get("${basedir}/docker-compose.yml").toString()
+
+assert buildLog.contains("Running: docker-compose -f $composeFile up --no-color" as CharSequence)
+assert buildLog.contains("Docker Compose has run successfully with message boomshakalaka")
+
+def cleanUpProcess = new ProcessBuilder("docker", "system", "prune", "-a", "-f").start().waitFor()
+
+assert cleanUpProcess == 0

--- a/src/main/java/com/dkanejs/maven/plugins/docker/compose/AbstractDockerComposeMojo.java
+++ b/src/main/java/com/dkanejs/maven/plugins/docker/compose/AbstractDockerComposeMojo.java
@@ -111,6 +111,12 @@ abstract class AbstractDockerComposeMojo extends AbstractMojo {
 	private String envFile;
 
 	/**
+	 * Environment variables defined directly in the POM, overriding envFile
+	 */
+	@Parameter(property = "dockerCompose.envVars")
+	private Map<String,String> envVars;
+
+	/**
 	 * Cmd to run and wait for exit status 0
 	 */
 	@Parameter(property = "dockerCompose.awaitCmd")
@@ -222,6 +228,13 @@ abstract class AbstractDockerComposeMojo extends AbstractMojo {
 			} catch (final IOException e) {
 				throw new MojoExecutionException(e.getMessage());
 			}
+		}
+
+		if (null != envVars) {
+			envVars.forEach((name, value) -> {
+				getLog().info(String.format("%s: %s", name, value));
+				environment.put(name, value);
+			});
 		}
 	}
 


### PR DESCRIPTION
Hey there,

This PR allows for the configuration of environment variables from the plugin's `<configuration>` block in pom.xml. This is useful for parameterization of `docker-compose.yml` files.

I've included tests and updated the README as well.

Closes #54.
