### PR TITLE
Add docker-compose pull support (closes #61)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*]
+[**]
 charset = utf-8
 end_of_line = lf
 indent_size = 4

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This plugin is designed to be light, fast and with minimum dependencies (only th
 ### Goals
 * up - runs `docker-compose up`
 * down - runs `docker-compose down`
+* pull - runs `docker-compose pull`
 
 ### Properties
 #### composeFile
@@ -300,7 +301,7 @@ Below has customised the location of the `docker-compose.yml` file and has three
                         <composeFile>${project.basedir}/docker-compose.yml</composeFile>
                         <ignorePullFailures>true</ignorePullFailures>
                     </configuration>
-                </execution>            
+                </execution>
                 <execution>
                     <id>up</id>
                     <phase>verify</phase>

--- a/README.md
+++ b/README.md
@@ -250,6 +250,20 @@ Additional option `removeImagesType` allows to specify `type` parameter of `--rm
 </configuration>
 ```
 
+#### ignorePullFailures
+`ignorePullFailures` - Ignores failures when executing the pull goal
+
+This adds `--ignore-pull-failures` to the `pull` command.
+
+The plugin will not ignore pull failures by default.
+
+This can be changed in the configuration section of the plugin:
+```xml
+<configuration>
+    <ignorePullFailures>true</ignorePullFailures>
+</configuration>
+```
+
 ## Configuration
 ### Default
 Below will allow use of the plugin from the `mvn` command line:
@@ -267,7 +281,7 @@ Below will allow use of the plugin from the `mvn` command line:
 This assumes the compose file is in the default location and will not run in any phase of the build.
 
 ### Advanced
-Below has customised the location of the `docker-compose.yml` file and has two executions defined:
+Below has customised the location of the `docker-compose.yml` file and has three executions defined:
 ```xml
 <build>
     <plugins>
@@ -276,6 +290,17 @@ Below has customised the location of the `docker-compose.yml` file and has two e
             <artifactId>docker-compose-maven-plugin</artifactId>
             <version>$VERSION</version>
             <executions>
+                <execution>
+                    <id>pull</id>
+                    <phase>verify</phase>
+                    <goals>
+                        <goal>pull</goal>
+                    </goals>
+                    <configuration>
+                        <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                        <ignorePullFailures>true</ignorePullFailures>
+                    </configuration>
+                </execution>            
                 <execution>
                     <id>up</id>
                     <phase>verify</phase>
@@ -305,5 +330,6 @@ Below has customised the location of the `docker-compose.yml` file and has two e
 ```
 
 This will run the following as part of the `verify` phase:
- 1. `docker-compose up -d` using a `docker-compose.yml` file in a custom location
- 2. `docker-compose down -v` using a `docker-compose.yml` file in a custom location
+ 1. `docker-compose pull --ignore-pull-failures` using a `docker-compose.yml` file in a custom location
+ 2. `docker-compose up -d` using a `docker-compose.yml` file in a custom location
+ 3. `docker-compose down -v` using a `docker-compose.yml` file in a custom location

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,9 @@
                                 <pomInclude>up-env-vars/pom.xml</pomInclude>
                                 <pomInclude>up-skip/pom.xml</pomInclude>
                                 <pomInclude>up-verbose/pom.xml</pomInclude>
+                                <pomInclude>pull/pom.xml</pomInclude>
+                                <pomInclude>pull-ignore-failures/pom.xml</pomInclude>
+                                <pomInclude>pull-skip/pom.xml</pomInclude>
                             </pomIncludes>
                             <postBuildHookScript>verify</postBuildHookScript>
                             <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>

--- a/src/it/pull-ignore-failures/docker-compose.yml
+++ b/src/it/pull-ignore-failures/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.2'
+services:
+  test:
+    image: busybox
+    container_name: mpdc-it-pull-ignore-failures
+    command: sleep 600

--- a/src/it/pull-ignore-failures/pom.xml
+++ b/src/it/pull-ignore-failures/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.dkanejs.maven.plugins.it</groupId>
+    <artifactId>pull-ignore-failures</artifactId>
+    <version>1.0</version>
+
+    <description>Verify "docker-compose pull --ignore-pull-failures" runs.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>pull</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>pull</goal>
+                        </goals>
+                        <configuration>
+                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                            <ignorePullFailures>true</ignorePullFailures>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/pull-ignore-failures/verify.groovy
+++ b/src/it/pull-ignore-failures/verify.groovy
@@ -1,0 +1,13 @@
+import java.nio.file.Paths
+
+String buildLog = new File("${basedir}/build.log").getText("UTF-8")
+
+String composeFile = Paths.get("${basedir}/docker-compose.yml").toString()
+
+assert buildLog.contains("Running: docker-compose -f $composeFile pull --ignore-pull-failures" as CharSequence)
+
+def cleanUpProcess = new ProcessBuilder("docker", "system", "prune", "-a", "-f").start().waitFor()
+
+assert cleanUpProcess == 0
+
+

--- a/src/it/pull-ignore-failures/verify.groovy
+++ b/src/it/pull-ignore-failures/verify.groovy
@@ -5,9 +5,3 @@ String buildLog = new File("${basedir}/build.log").getText("UTF-8")
 String composeFile = Paths.get("${basedir}/docker-compose.yml").toString()
 
 assert buildLog.contains("Running: docker-compose -f $composeFile pull --ignore-pull-failures" as CharSequence)
-
-def cleanUpProcess = new ProcessBuilder("docker", "system", "prune", "-a", "-f").start().waitFor()
-
-assert cleanUpProcess == 0
-
-

--- a/src/it/pull-skip/docker-compose.yml
+++ b/src/it/pull-skip/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.2'
+services:
+  test:
+    image: busybox
+    container_name: mpdc-it-pull-skip
+    command: echo -e Docker Compose has run successfully

--- a/src/it/pull-skip/pom.xml
+++ b/src/it/pull-skip/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.dkanejs.maven.plugins.it</groupId>
+    <artifactId>pull-skip</artifactId>
+    <version>1.0</version>
+
+    <description>Verify "docker-compose pull" skips execution.</description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+                        <id>pull</id>
+                        <phase>verify</phase>
+						<goals>
+							<goal>pull</goal>
+						</goals>
+						<configuration>
+							<skip>true</skip>
+                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+							<verbose>true</verbose>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/pull-skip/pom.xml
+++ b/src/it/pull-skip/pom.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.dkanejs.maven.plugins.it</groupId>
+    <groupId>com.dkanejs.maven.plugins.it</groupId>
     <artifactId>pull-skip</artifactId>
     <version>1.0</version>
 
     <description>Verify "docker-compose pull" skips execution.</description>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>@project.groupId@</groupId>
-				<artifactId>@project.artifactId@</artifactId>
-				<version>@project.version@</version>
-				<executions>
-					<execution>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
                         <id>pull</id>
                         <phase>verify</phase>
-						<goals>
-							<goal>pull</goal>
-						</goals>
-						<configuration>
-							<skip>true</skip>
+                        <goals>
+                            <goal>pull</goal>
+                        </goals>
+                        <configuration>
+                            <skip>true</skip>
                             <composeFile>${project.basedir}/docker-compose.yml</composeFile>
-							<verbose>true</verbose>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+                            <verbose>true</verbose>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/it/pull-skip/verify.groovy
+++ b/src/it/pull-skip/verify.groovy
@@ -1,8 +1,4 @@
 String buildLog = new File("${basedir}/build.log").getText("UTF-8")
 
 assert buildLog.contains("Skipping execution" as CharSequence)
-assert !buildLog.contains("Downloaded newer image for busybox:latest")
-
-def cleanUpProcess = new ProcessBuilder("docker", "system", "prune", "-a", "-f").start().waitFor()
-
-assert cleanUpProcess == 0
+assert !buildLog.contains("Downloaded newer image for busybox:latest" as CharSequence)

--- a/src/it/pull-skip/verify.groovy
+++ b/src/it/pull-skip/verify.groovy
@@ -1,0 +1,8 @@
+String buildLog = new File("${basedir}/build.log").getText("UTF-8")
+
+assert buildLog.contains("Skipping execution" as CharSequence)
+assert !buildLog.contains("Downloaded newer image for busybox:latest")
+
+def cleanUpProcess = new ProcessBuilder("docker", "system", "prune", "-a", "-f").start().waitFor()
+
+assert cleanUpProcess == 0

--- a/src/it/pull/docker-compose.yml
+++ b/src/it/pull/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.2'
+services:
+  test:
+    image: busybox
+    container_name: mpdc-it-pull
+    command: sleep 600

--- a/src/it/pull/pom.xml
+++ b/src/it/pull/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.dkanejs.maven.plugins.it</groupId>
+    <artifactId>pull</artifactId>
+    <version>1.0</version>
+
+    <description>Verify "docker-compose pull" runs.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>pull</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>pull</goal>
+                        </goals>
+                        <configuration>
+                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/pull/verify.groovy
+++ b/src/it/pull/verify.groovy
@@ -1,0 +1,13 @@
+import java.nio.file.Paths
+
+String buildLog = new File("${basedir}/build.log").getText("UTF-8")
+
+String composeFile = Paths.get("${basedir}/docker-compose.yml").toString()
+
+assert buildLog.contains("Running: docker-compose -f $composeFile pull" as CharSequence)
+
+def cleanUpProcess = new ProcessBuilder("docker", "system", "prune", "-a", "-f").start().waitFor()
+
+assert cleanUpProcess == 0
+
+

--- a/src/it/pull/verify.groovy
+++ b/src/it/pull/verify.groovy
@@ -5,9 +5,3 @@ String buildLog = new File("${basedir}/build.log").getText("UTF-8")
 String composeFile = Paths.get("${basedir}/docker-compose.yml").toString()
 
 assert buildLog.contains("Running: docker-compose -f $composeFile pull" as CharSequence)
-
-def cleanUpProcess = new ProcessBuilder("docker", "system", "prune", "-a", "-f").start().waitFor()
-
-assert cleanUpProcess == 0
-
-

--- a/src/main/java/com/dkanejs/maven/plugins/docker/compose/AbstractDockerComposeMojo.java
+++ b/src/main/java/com/dkanejs/maven/plugins/docker/compose/AbstractDockerComposeMojo.java
@@ -19,6 +19,7 @@ import java.util.Properties;
 
 
 abstract class AbstractDockerComposeMojo extends AbstractMojo {
+<<<<<<< HEAD
     /**
      * Specify an alternate project name
      */
@@ -181,6 +182,339 @@ abstract class AbstractDockerComposeMojo extends AbstractMojo {
         } else {
             composeFilePaths.add(Paths.get(this.composeFile).toString());
         }
+||||||| merged common ancestors
+	/**
+	 * Specify an alternate project name
+	 */
+	@Parameter(property = "dockerCompose.projectName")
+	private String projectName;
+
+	/**
+	 * Docker host to interact with
+	 */
+	@Parameter(property = "dockerCompose.host")
+	private String host;
+
+	/**
+	 * Remove volumes on down
+	 */
+	@Parameter(defaultValue = "false", property = "dockerCompose.removeVolumes")
+	boolean removeVolumes;
+
+	/**
+	 * Remove images on down
+	 */
+	@Parameter(defaultValue = "false", property = "dockerCompose.removeImages")
+	boolean removeImages;
+
+	/**
+	 * 'type' of images to remove on down
+	 */
+	@Parameter(defaultValue = "all", property = "dockerCompose.removeImages.type")
+	String removeImagesType;
+
+	/**
+	 * Run in detached mode
+	 */
+	@Parameter(defaultValue = "false", property = "dockerCompose.detached")
+	protected boolean detachedMode;
+
+	/**
+	 * Build containers before run
+	 */
+	@Parameter(defaultValue = "false", property = "dockerCompose.build")
+	protected boolean build;
+
+	/**
+	 * The location of the Compose file. Value of this property is ignored if {@link #composeFiles} is set and non-empty.
+	 */
+	@Parameter(defaultValue = "${project.basedir}/src/main/resources/docker-compose.yml", property = "dockerCompose.file")
+	private String composeFile;
+
+	/**
+	 * Location of the Compose files. If this property is set and non-empty then {@link #composeFile} is ignored.
+	 */
+	@Parameter(property = "dockerCompose.composeFiles")
+	private List<String> composeFiles;
+
+	/**
+	 * Names of services. If this property is set only the configured services will be controlled.
+	 */
+	@Parameter(property = "dockerCompose.services")
+	protected List<String> services;
+
+	/**
+	 * The Compose Api Version
+	 */
+	@Parameter(property = "dockerCompose.apiVersion")
+	private String apiVersion;
+
+	/**
+	 * Verbose
+	 */
+	@Parameter(defaultValue = "false", property = "dockerCompose.verbose")
+	private boolean verbose;
+
+	/**
+	 * Skip
+	 */
+	@Parameter(defaultValue = "false", property = "dockerCompose.skip")
+	boolean skip;
+
+	/**
+	 * Remove containers for services not defined in the Compose file
+	 */
+	@Parameter(defaultValue = "false", property = "dockerCompose.removeOrphans")
+	boolean removeOrphans;
+
+	/**
+	 * Properties file from which docker environment variables are set
+	 */
+	@Parameter(property = "dockerCompose.envFile")
+	private String envFile;
+
+	/**
+	 * Environment variables defined directly in the POM, overriding envFile
+	 */
+	@Parameter(property = "dockerCompose.envVars")
+	private Map<String,String> envVars;
+
+	/**
+	 * Cmd to run and wait for exit status 0
+	 */
+	@Parameter(property = "dockerCompose.awaitCmd")
+	String awaitCmd;
+
+	/**
+	 * Arguments to awaitCmd (comma separated)
+	 */
+	@Parameter(property = "dockerCompose.awaitCmdArgs")
+	String awaitCmdArgs;
+
+	/**
+	 * Timeout for await (seconds)
+	 */
+	@Parameter(property = "dockerCompose.awaitTimeout", defaultValue = "30")
+	int awaitTimeout;
+
+	void execute(List<String> args) throws MojoExecutionException {
+
+		ProcessBuilder pb = buildProcess(args);
+
+		getLog().info("Running: " + StringUtils.join(pb.command().iterator(), " "));
+
+		try {
+			Process p = pb.start();
+
+			BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()));
+
+			String line;
+
+			while ((line = br.readLine()) != null)
+				getLog().info(line);
+
+			int ec = p.waitFor();
+
+			if (ec != 0)
+				throw new DockerComposeException(IOUtil.toString(p.getErrorStream()));
+
+		} catch (Exception e) {
+			throw new MojoExecutionException(e.getMessage());
+		}
+	}
+
+	private ProcessBuilder buildProcess(List<String> args) throws MojoExecutionException {
+
+		List<String> command = buildCmd(args);
+
+		ProcessBuilder pb = new ProcessBuilder(command).inheritIO();
+
+		setEnvironment(pb);
+
+		return pb;
+	}
+
+	private List<String> buildCmd(List<String> args) {
+		List<String> composeFilePaths = new ArrayList<>();
+
+		if (composeFiles != null && !composeFiles.isEmpty()) {
+			composeFiles.stream()
+				.map(Paths::get)
+				.map(Path::toString)
+				.forEachOrdered(composeFilePaths::add);
+		} else {
+			composeFilePaths.add(Paths.get(this.composeFile).toString());
+		}
+=======
+	/**
+	 * Specify an alternate project name
+	 */
+	@Parameter(property = "dockerCompose.projectName")
+	private String projectName;
+
+	/**
+	 * Docker host to interact with
+	 */
+	@Parameter(property = "dockerCompose.host")
+	private String host;
+
+	/**
+	 * Remove volumes on down
+	 */
+	@Parameter(defaultValue = "false", property = "dockerCompose.removeVolumes")
+	boolean removeVolumes;
+
+	/**
+	 * Remove images on down
+	 */
+	@Parameter(defaultValue = "false", property = "dockerCompose.removeImages")
+	boolean removeImages;
+
+	/**
+	 * 'type' of images to remove on down
+	 */
+	@Parameter(defaultValue = "all", property = "dockerCompose.removeImages.type")
+	String removeImagesType;
+
+	/**
+	 * Run in detached mode
+	 */
+	@Parameter(defaultValue = "false", property = "dockerCompose.detached")
+	protected boolean detachedMode;
+
+	/**
+	 * Build containers before run
+	 */
+	@Parameter(defaultValue = "false", property = "dockerCompose.build")
+	protected boolean build;
+
+	/**
+	 * The location of the Compose file. Value of this property is ignored if {@link #composeFiles} is set and non-empty.
+	 */
+	@Parameter(defaultValue = "${project.basedir}/src/main/resources/docker-compose.yml", property = "dockerCompose.file")
+	private String composeFile;
+
+	/**
+	 * Location of the Compose files. If this property is set and non-empty then {@link #composeFile} is ignored.
+	 */
+	@Parameter(property = "dockerCompose.composeFiles")
+	private List<String> composeFiles;
+
+	/**
+	 * Names of services. If this property is set only the configured services will be controlled.
+	 */
+	@Parameter(property = "dockerCompose.services")
+	protected List<String> services;
+
+	/**
+	 * The Compose Api Version
+	 */
+	@Parameter(property = "dockerCompose.apiVersion")
+	private String apiVersion;
+
+	/**
+	 * Verbose
+	 */
+	@Parameter(defaultValue = "false", property = "dockerCompose.verbose")
+	private boolean verbose;
+
+	/**
+	 * Skip
+	 */
+	@Parameter(defaultValue = "false", property = "dockerCompose.skip")
+	boolean skip;
+
+	/**
+	 * Remove containers for services not defined in the Compose file
+	 */
+	@Parameter(defaultValue = "false", property = "dockerCompose.removeOrphans")
+	boolean removeOrphans;
+
+	/**
+	 * Properties file from which docker environment variables are set
+	 */
+	@Parameter(property = "dockerCompose.envFile")
+	private String envFile;
+
+	/**
+	 * Environment variables defined directly in the POM, overriding envFile
+	 */
+	@Parameter(property = "dockerCompose.envVars")
+	private Map<String,String> envVars;
+
+	/**
+	 * Cmd to run and wait for exit status 0
+	 */
+	@Parameter(property = "dockerCompose.awaitCmd")
+	String awaitCmd;
+
+	/**
+	 * Arguments to awaitCmd (comma separated)
+	 */
+	@Parameter(property = "dockerCompose.awaitCmdArgs")
+	String awaitCmdArgs;
+
+	/**
+	 * Timeout for await (seconds)
+	 */
+	@Parameter(property = "dockerCompose.awaitTimeout", defaultValue = "30")
+	int awaitTimeout;
+
+	/**
+	 * Ignore pull failures
+	 */
+	@Parameter(defaultValue = "false", property = "dockerCompose.ignorePullFailures")
+	boolean ignorePullFailures;
+
+	void execute(List<String> args) throws MojoExecutionException {
+
+		ProcessBuilder pb = buildProcess(args);
+
+		getLog().info("Running: " + StringUtils.join(pb.command().iterator(), " "));
+
+		try {
+			Process p = pb.start();
+
+			BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()));
+
+			String line;
+
+			while ((line = br.readLine()) != null)
+				getLog().info(line);
+
+			int ec = p.waitFor();
+
+			if (ec != 0)
+				throw new DockerComposeException(IOUtil.toString(p.getErrorStream()));
+
+		} catch (Exception e) {
+			throw new MojoExecutionException(e.getMessage());
+		}
+	}
+
+	private ProcessBuilder buildProcess(List<String> args) throws MojoExecutionException {
+
+		List<String> command = buildCmd(args);
+
+		ProcessBuilder pb = new ProcessBuilder(command).inheritIO();
+
+		setEnvironment(pb);
+
+		return pb;
+	}
+
+	private List<String> buildCmd(List<String> args) {
+		List<String> composeFilePaths = new ArrayList<>();
+
+		if (composeFiles != null && !composeFiles.isEmpty()) {
+			composeFiles.stream()
+				.map(Paths::get)
+				.map(Path::toString)
+				.forEachOrdered(composeFilePaths::add);
+		} else {
+			composeFilePaths.add(Paths.get(this.composeFile).toString());
+		}
+>>>>>>> Add support for docker-compose pull
 
         getLog().info("Docker Compose Files: " + String.join(", ", composeFilePaths));
 
@@ -237,9 +571,20 @@ abstract class AbstractDockerComposeMojo extends AbstractMojo {
         }
     }
 
+<<<<<<< HEAD
     enum Command {
         UP("up"),
         DOWN("down");
+||||||| merged common ancestors
+	enum Command {
+		UP("up"),
+		DOWN("down");
+=======
+	enum Command {
+		UP("up"),
+		DOWN("down"),
+		PULL("pull");
+>>>>>>> Add support for docker-compose pull
 
         @SuppressWarnings("unused")
         private String value;

--- a/src/main/java/com/dkanejs/maven/plugins/docker/compose/AbstractDockerComposeMojo.java
+++ b/src/main/java/com/dkanejs/maven/plugins/docker/compose/AbstractDockerComposeMojo.java
@@ -19,7 +19,7 @@ import java.util.Properties;
 
 
 abstract class AbstractDockerComposeMojo extends AbstractMojo {
-<<<<<<< HEAD
+
     /**
      * Specify an alternate project name
      */
@@ -134,6 +134,13 @@ abstract class AbstractDockerComposeMojo extends AbstractMojo {
     @Parameter(property = "dockerCompose.awaitTimeout", defaultValue = "30")
     int awaitTimeout;
 
+
+    /**
+     * Ignore pull failures
+     */
+    @Parameter(defaultValue = "false", property = "dockerCompose.ignorePullFailures")
+    boolean ignorePullFailures;
+
     void execute(List<String> args) throws MojoExecutionException {
 
         ProcessBuilder pb = buildProcess(args);
@@ -176,345 +183,12 @@ abstract class AbstractDockerComposeMojo extends AbstractMojo {
 
         if (composeFiles != null && !composeFiles.isEmpty()) {
             composeFiles.stream()
-                    .map(Paths::get)
-                    .map(Path::toString)
-                    .forEachOrdered(composeFilePaths::add);
+                .map(Paths::get)
+                .map(Path::toString)
+                .forEachOrdered(composeFilePaths::add);
         } else {
             composeFilePaths.add(Paths.get(this.composeFile).toString());
         }
-||||||| merged common ancestors
-	/**
-	 * Specify an alternate project name
-	 */
-	@Parameter(property = "dockerCompose.projectName")
-	private String projectName;
-
-	/**
-	 * Docker host to interact with
-	 */
-	@Parameter(property = "dockerCompose.host")
-	private String host;
-
-	/**
-	 * Remove volumes on down
-	 */
-	@Parameter(defaultValue = "false", property = "dockerCompose.removeVolumes")
-	boolean removeVolumes;
-
-	/**
-	 * Remove images on down
-	 */
-	@Parameter(defaultValue = "false", property = "dockerCompose.removeImages")
-	boolean removeImages;
-
-	/**
-	 * 'type' of images to remove on down
-	 */
-	@Parameter(defaultValue = "all", property = "dockerCompose.removeImages.type")
-	String removeImagesType;
-
-	/**
-	 * Run in detached mode
-	 */
-	@Parameter(defaultValue = "false", property = "dockerCompose.detached")
-	protected boolean detachedMode;
-
-	/**
-	 * Build containers before run
-	 */
-	@Parameter(defaultValue = "false", property = "dockerCompose.build")
-	protected boolean build;
-
-	/**
-	 * The location of the Compose file. Value of this property is ignored if {@link #composeFiles} is set and non-empty.
-	 */
-	@Parameter(defaultValue = "${project.basedir}/src/main/resources/docker-compose.yml", property = "dockerCompose.file")
-	private String composeFile;
-
-	/**
-	 * Location of the Compose files. If this property is set and non-empty then {@link #composeFile} is ignored.
-	 */
-	@Parameter(property = "dockerCompose.composeFiles")
-	private List<String> composeFiles;
-
-	/**
-	 * Names of services. If this property is set only the configured services will be controlled.
-	 */
-	@Parameter(property = "dockerCompose.services")
-	protected List<String> services;
-
-	/**
-	 * The Compose Api Version
-	 */
-	@Parameter(property = "dockerCompose.apiVersion")
-	private String apiVersion;
-
-	/**
-	 * Verbose
-	 */
-	@Parameter(defaultValue = "false", property = "dockerCompose.verbose")
-	private boolean verbose;
-
-	/**
-	 * Skip
-	 */
-	@Parameter(defaultValue = "false", property = "dockerCompose.skip")
-	boolean skip;
-
-	/**
-	 * Remove containers for services not defined in the Compose file
-	 */
-	@Parameter(defaultValue = "false", property = "dockerCompose.removeOrphans")
-	boolean removeOrphans;
-
-	/**
-	 * Properties file from which docker environment variables are set
-	 */
-	@Parameter(property = "dockerCompose.envFile")
-	private String envFile;
-
-	/**
-	 * Environment variables defined directly in the POM, overriding envFile
-	 */
-	@Parameter(property = "dockerCompose.envVars")
-	private Map<String,String> envVars;
-
-	/**
-	 * Cmd to run and wait for exit status 0
-	 */
-	@Parameter(property = "dockerCompose.awaitCmd")
-	String awaitCmd;
-
-	/**
-	 * Arguments to awaitCmd (comma separated)
-	 */
-	@Parameter(property = "dockerCompose.awaitCmdArgs")
-	String awaitCmdArgs;
-
-	/**
-	 * Timeout for await (seconds)
-	 */
-	@Parameter(property = "dockerCompose.awaitTimeout", defaultValue = "30")
-	int awaitTimeout;
-
-	void execute(List<String> args) throws MojoExecutionException {
-
-		ProcessBuilder pb = buildProcess(args);
-
-		getLog().info("Running: " + StringUtils.join(pb.command().iterator(), " "));
-
-		try {
-			Process p = pb.start();
-
-			BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()));
-
-			String line;
-
-			while ((line = br.readLine()) != null)
-				getLog().info(line);
-
-			int ec = p.waitFor();
-
-			if (ec != 0)
-				throw new DockerComposeException(IOUtil.toString(p.getErrorStream()));
-
-		} catch (Exception e) {
-			throw new MojoExecutionException(e.getMessage());
-		}
-	}
-
-	private ProcessBuilder buildProcess(List<String> args) throws MojoExecutionException {
-
-		List<String> command = buildCmd(args);
-
-		ProcessBuilder pb = new ProcessBuilder(command).inheritIO();
-
-		setEnvironment(pb);
-
-		return pb;
-	}
-
-	private List<String> buildCmd(List<String> args) {
-		List<String> composeFilePaths = new ArrayList<>();
-
-		if (composeFiles != null && !composeFiles.isEmpty()) {
-			composeFiles.stream()
-				.map(Paths::get)
-				.map(Path::toString)
-				.forEachOrdered(composeFilePaths::add);
-		} else {
-			composeFilePaths.add(Paths.get(this.composeFile).toString());
-		}
-=======
-	/**
-	 * Specify an alternate project name
-	 */
-	@Parameter(property = "dockerCompose.projectName")
-	private String projectName;
-
-	/**
-	 * Docker host to interact with
-	 */
-	@Parameter(property = "dockerCompose.host")
-	private String host;
-
-	/**
-	 * Remove volumes on down
-	 */
-	@Parameter(defaultValue = "false", property = "dockerCompose.removeVolumes")
-	boolean removeVolumes;
-
-	/**
-	 * Remove images on down
-	 */
-	@Parameter(defaultValue = "false", property = "dockerCompose.removeImages")
-	boolean removeImages;
-
-	/**
-	 * 'type' of images to remove on down
-	 */
-	@Parameter(defaultValue = "all", property = "dockerCompose.removeImages.type")
-	String removeImagesType;
-
-	/**
-	 * Run in detached mode
-	 */
-	@Parameter(defaultValue = "false", property = "dockerCompose.detached")
-	protected boolean detachedMode;
-
-	/**
-	 * Build containers before run
-	 */
-	@Parameter(defaultValue = "false", property = "dockerCompose.build")
-	protected boolean build;
-
-	/**
-	 * The location of the Compose file. Value of this property is ignored if {@link #composeFiles} is set and non-empty.
-	 */
-	@Parameter(defaultValue = "${project.basedir}/src/main/resources/docker-compose.yml", property = "dockerCompose.file")
-	private String composeFile;
-
-	/**
-	 * Location of the Compose files. If this property is set and non-empty then {@link #composeFile} is ignored.
-	 */
-	@Parameter(property = "dockerCompose.composeFiles")
-	private List<String> composeFiles;
-
-	/**
-	 * Names of services. If this property is set only the configured services will be controlled.
-	 */
-	@Parameter(property = "dockerCompose.services")
-	protected List<String> services;
-
-	/**
-	 * The Compose Api Version
-	 */
-	@Parameter(property = "dockerCompose.apiVersion")
-	private String apiVersion;
-
-	/**
-	 * Verbose
-	 */
-	@Parameter(defaultValue = "false", property = "dockerCompose.verbose")
-	private boolean verbose;
-
-	/**
-	 * Skip
-	 */
-	@Parameter(defaultValue = "false", property = "dockerCompose.skip")
-	boolean skip;
-
-	/**
-	 * Remove containers for services not defined in the Compose file
-	 */
-	@Parameter(defaultValue = "false", property = "dockerCompose.removeOrphans")
-	boolean removeOrphans;
-
-	/**
-	 * Properties file from which docker environment variables are set
-	 */
-	@Parameter(property = "dockerCompose.envFile")
-	private String envFile;
-
-	/**
-	 * Environment variables defined directly in the POM, overriding envFile
-	 */
-	@Parameter(property = "dockerCompose.envVars")
-	private Map<String,String> envVars;
-
-	/**
-	 * Cmd to run and wait for exit status 0
-	 */
-	@Parameter(property = "dockerCompose.awaitCmd")
-	String awaitCmd;
-
-	/**
-	 * Arguments to awaitCmd (comma separated)
-	 */
-	@Parameter(property = "dockerCompose.awaitCmdArgs")
-	String awaitCmdArgs;
-
-	/**
-	 * Timeout for await (seconds)
-	 */
-	@Parameter(property = "dockerCompose.awaitTimeout", defaultValue = "30")
-	int awaitTimeout;
-
-	/**
-	 * Ignore pull failures
-	 */
-	@Parameter(defaultValue = "false", property = "dockerCompose.ignorePullFailures")
-	boolean ignorePullFailures;
-
-	void execute(List<String> args) throws MojoExecutionException {
-
-		ProcessBuilder pb = buildProcess(args);
-
-		getLog().info("Running: " + StringUtils.join(pb.command().iterator(), " "));
-
-		try {
-			Process p = pb.start();
-
-			BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()));
-
-			String line;
-
-			while ((line = br.readLine()) != null)
-				getLog().info(line);
-
-			int ec = p.waitFor();
-
-			if (ec != 0)
-				throw new DockerComposeException(IOUtil.toString(p.getErrorStream()));
-
-		} catch (Exception e) {
-			throw new MojoExecutionException(e.getMessage());
-		}
-	}
-
-	private ProcessBuilder buildProcess(List<String> args) throws MojoExecutionException {
-
-		List<String> command = buildCmd(args);
-
-		ProcessBuilder pb = new ProcessBuilder(command).inheritIO();
-
-		setEnvironment(pb);
-
-		return pb;
-	}
-
-	private List<String> buildCmd(List<String> args) {
-		List<String> composeFilePaths = new ArrayList<>();
-
-		if (composeFiles != null && !composeFiles.isEmpty()) {
-			composeFiles.stream()
-				.map(Paths::get)
-				.map(Path::toString)
-				.forEachOrdered(composeFilePaths::add);
-		} else {
-			composeFilePaths.add(Paths.get(this.composeFile).toString());
-		}
->>>>>>> Add support for docker-compose pull
 
         getLog().info("Docker Compose Files: " + String.join(", ", composeFilePaths));
 
@@ -571,20 +245,10 @@ abstract class AbstractDockerComposeMojo extends AbstractMojo {
         }
     }
 
-<<<<<<< HEAD
     enum Command {
         UP("up"),
-        DOWN("down");
-||||||| merged common ancestors
-	enum Command {
-		UP("up"),
-		DOWN("down");
-=======
-	enum Command {
-		UP("up"),
-		DOWN("down"),
-		PULL("pull");
->>>>>>> Add support for docker-compose pull
+        DOWN("down"),
+        PULL("pull");
 
         @SuppressWarnings("unused")
         private String value;

--- a/src/main/java/com/dkanejs/maven/plugins/docker/compose/DockerComposeDownMojo.java
+++ b/src/main/java/com/dkanejs/maven/plugins/docker/compose/DockerComposeDownMojo.java
@@ -37,6 +37,6 @@ public class DockerComposeDownMojo extends AbstractDockerComposeMojo {
             args.add("--remove-orphans");
         }
 
-            super.execute(args);
+        super.execute(args);
     }
 }

--- a/src/main/java/com/dkanejs/maven/plugins/docker/compose/DockerComposePullMojo.java
+++ b/src/main/java/com/dkanejs/maven/plugins/docker/compose/DockerComposePullMojo.java
@@ -1,0 +1,35 @@
+package com.dkanejs.maven.plugins.docker.compose;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * docker-compose pull
+ */
+@SuppressWarnings("unused")
+@Mojo(name = "pull", threadSafe = true)
+public class DockerComposePullMojo extends AbstractDockerComposeMojo {
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+
+		if (skip) {
+			getLog().info("Skipping execution");
+			return;
+		}
+
+		List<String> args = new ArrayList<>();
+		args.add(Command.PULL.getValue());
+
+		if (ignorePullFailures) {
+			getLog().info("Ignore pull failures");
+			args.add("--ignore-pull-failures");
+		}
+
+		super.execute(args);
+	}
+}


### PR DESCRIPTION
Add support for docker-compose pull by adding an additional goal `pull`. Additionally, added a property that can configure the --ignore-pull-failures parameter on the pull command.

This closes #61 .