### PR TITLE
Making release 2.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Docker Compose Maven Plugin
-[![Build Status](https://travis-ci.org/dkanejs/docker-compose-maven-plugin.svg?branch=master)](https://travis-ci.org/dkanejs/docker-compose-maven-plugin)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.dkanejs.maven.plugins/docker-compose-maven-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.dkanejs.maven.plugins/docker-compose-maven-plugin)
 
 ## Quickstart

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.dkanejs.maven.plugins</groupId>
     <artifactId>docker-compose-maven-plugin</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
 
     <packaging>maven-plugin</packaging>
 

--- a/src/it/pull-ignore-failures/docker-compose.yml
+++ b/src/it/pull-ignore-failures/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.2'
 services:
   test:
-    image: busybox
+    image: thisimagedoesnotexist
     container_name: mpdc-it-pull-ignore-failures
     command: sleep 600


### PR DESCRIPTION
update POM version
remove TravisCI build badge in readme
update 'pull ignore failures' test to pull an image that does not exist