### PR TITLE
Update pull to use --no-parallel

### DIFF
--- a/src/main/java/com/dkanejs/maven/plugins/docker/compose/DockerComposePullMojo.java
+++ b/src/main/java/com/dkanejs/maven/plugins/docker/compose/DockerComposePullMojo.java
@@ -28,6 +28,7 @@ public class DockerComposePullMojo extends AbstractDockerComposeMojo {
         if (ignorePullFailures) {
             getLog().info("Ignore pull failures");
             args.add("--ignore-pull-failures");
+            args.add("--no-parallel");
         }
 
         super.execute(args);


### PR DESCRIPTION
Use `--no-parallel` Until docker fix this:

https://github.com/docker/compose/issues/7127