### PR TITLE
Added custom cli arg option to set things like --tlsverify

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,14 @@ This can be changed in the configuration section of the plugin:
 </configuration>
 ```
 
+#### cliArgs
+`cliArgs` - define custom commandline arguments
+```xml
+<configuration>
+    <cliArgs>--tlsverify</cliArgs>
+</configuration>
+```
+
 #### build
 `build` - Build images before starting containers
 

--- a/src/it/up-cliArgs/docker-compose.yml
+++ b/src/it/up-cliArgs/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.2'
+services:
+  test:
+    image: busybox
+    container_name: mpdc-it-up-verbose
+    command: echo -e Docker Compose has run successfully

--- a/src/it/up-cliArgs/pom.xml
+++ b/src/it/up-cliArgs/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.dkanejs.maven.plugins.it</groupId>
+    <artifactId>up-verbose</artifactId>
+    <version>1.0</version>
+
+    <description>Verify "docker-compose up --verbose" runs.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>up</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>up</goal>
+                        </goals>
+                        <configuration>
+                            <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                            <detachedMode>false</detachedMode>
+                            <cliArgs>--tlsverify</cliArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/up-cliArgs/verify.groovy
+++ b/src/it/up-cliArgs/verify.groovy
@@ -1,0 +1,6 @@
+import java.nio.file.Paths
+
+String buildLog = new File("${basedir}/build.log").getText("UTF-8")
+String composeFile = Paths.get("${basedir}/docker-compose.yml").toString()
+
+assert buildLog.contains("Running: docker-compose -f $composeFile --tlsverify up --no-color" as CharSequence)

--- a/src/main/java/com/dkanejs/maven/plugins/docker/compose/AbstractDockerComposeMojo.java
+++ b/src/main/java/com/dkanejs/maven/plugins/docker/compose/AbstractDockerComposeMojo.java
@@ -87,6 +87,12 @@ abstract class AbstractDockerComposeMojo extends AbstractMojo {
     protected List<String> services;
 
     /**
+     * Custom cli arguments for docker compose
+     */
+    @Parameter(property = "dockerCompose.cliArgs")
+    private String cliArgs;
+
+    /**
      * The Compose Api Version
      */
     @Parameter(property = "dockerCompose.apiVersion")
@@ -212,6 +218,10 @@ abstract class AbstractDockerComposeMojo extends AbstractMojo {
         if (host != null) {
             cmd.add("-H");
             cmd.add(host);
+        }
+
+        if (cliArgs != null) {
+            cmd.add(cliArgs);
         }
 
         if (projectName != null) {


### PR DESCRIPTION
Maybe I missed something. But it would be nice to add custom cli arguments to every single command. Like --tlsverify. Actually it is not possible to connect to a remote secure docker daemon