### PR TITLE
Maven dependency now is a plugin fragment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 Available on Maven Central.
 
 ```xml
-<dependency>
+<plugin>
     <groupId>com.dkanejs.maven.plugins</groupId>
     <artifactId>docker-compose-maven-plugin</artifactId>
     <version>$VERSION</version>
-</dependency>
+</plugin>
 ```
 
 ## About


### PR DESCRIPTION
Hey, thank you very much for this very useful plugin. When I copied the dependency fragment from the readme and added it to the pom I asked myself why this is not a plugin dependency. How do you think about fixing it in the example. Kind regards Conni